### PR TITLE
Fix to honor image's original colormap

### DIFF
--- a/Joystick.c
+++ b/Joystick.c
@@ -351,7 +351,7 @@ void GetNextReport(USB_JoystickReport_Input_t* const ReportData) {
 	         xpos--;
 	   }
 	   
-	   if ((image_data[(xpos / 8)+(ypos*40)] & 1 << (xpos % 8)) && (xpos >= 0))
+	   if (!(image_data[(xpos / 8)+(ypos*40)] & 1 << (xpos % 8)) && (xpos >= 0))
 	      ReportData->Button |= 0x4;
 	      
 	   if (xpos <= 0 && ypos >= 120-1) done_printing = true;


### PR DESCRIPTION
I've inverted the logical conditional around whether the A button is pressed, because whites are being converted to black. I don't know if that was a conscious decision (haven't reviewed bin2c.py closely}, but inverting this conditional lookup will retain whites and black as the original image intended.