### PR TITLE
Update converters to allow inverted or original colormap

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ $ python png2c.py splatoonpattern.png
 ```
 Substitute your own .png image to generate the `image.c` file necessary to print. Just make sure your image is in the `Switch-Fightstick` directory.
 
+To generate an inverted colormap of the image:
+
+```
+$ python png2c.py -i splatoonpattern.png
+```
+
 #### What the dither?
 As previously mentioned, png2c.py will dither the input image if you supply an image that is not already made up of only black and white pixels. Say you want to print this bomb image you created...
 

--- a/bin2c.py
+++ b/bin2c.py
@@ -1,20 +1,46 @@
 #!/bin/python
 
-import sys
+import sys, getopt
 
-data = open(sys.argv[1], 'rb').read()
+def main(argv):
+  opts, args = getopt.getopt(argv, "hi")
+  data = open(args[0], 'rb').read()
 
-str_out = "#include <stdint.h>\n#include <avr/pgmspace.h>\n\nconst uint8_t image_data[0x12c1] PROGMEM = {"
-for i in range(0, (320*120) / 8):
-   val = 0;
-   
-   for j in range(0, 8):
-      val |= ord(data[(i * 8) + j]) << j
-   
-   val = ~val & 0xFF;
-   str_out += hex(val) + ", "
-   
-str_out += "0x0};"
-   
-with open('image.c', 'w') as f:
-  f.write(str_out)
+  invertColormap = False
+  for opt, arg in opts:
+    if opt == '-h':
+      usage()
+      sys.exit()
+    elif opt == '-i':
+      invertColormap = True
+
+  str_out = "#include <stdint.h>\n#include <avr/pgmspace.h>\n\nconst uint8_t image_data[0x12c1] PROGMEM = {"
+  for i in range(0, (320*120) / 8):
+    val = 0;
+
+    for j in range(0, 8):
+        val |= ord(data[(i * 8) + j]) << j
+
+    if (invertColormap):
+      val = ~val & 0xFF;
+    else:
+      val = val & 0xFF;
+
+    str_out += hex(val) + ", "
+
+  str_out += "0x0};"
+
+  with open('image.c', 'w') as f:
+    f.write(str_out)
+
+  if (invertColormap):
+      print("{} converted with inverted colormap and saved to image.c".format(args[0]))
+  else:
+      print("{} converted with original colormap and saved to image.c".format(args[0]))
+
+def usage():
+  print("To convert to image.c: bin2c.py yourImage.data")
+  print("To convert to an inverted image.c: bin2c.py -i yourImage.data")
+
+if __name__ == "__main__":
+  main(sys.argv[1:])

--- a/png2c.py
+++ b/png2c.py
@@ -4,9 +4,11 @@ import sys, os, getopt
 from PIL import Image
 
 def main(argv):
-  opts, args = getopt.getopt(argv, "psh")
+  opts, args = getopt.getopt(argv, "pshi")
   previewBilevel = False
   saveBilevel = False
+  invertColormap = False
+
   for opt, arg in opts:
     if opt == '-h':
       usage()
@@ -15,6 +17,8 @@ def main(argv):
       previewBilevel = True
     elif opt == '-s':
       saveBilevel = True
+    elif opt == '-i':
+      invertColormap = True
 
   im = Image.open(args[0])                # import 320x120 png
   if not (im.size[0] == 320 and im.size[1] == 120):
@@ -29,31 +33,39 @@ def main(argv):
     im.save("bilevel_" + args[0])
     print("Bilevel version of " + args[0] + " saved as bilevel_" + args[0])
   if not (previewBilevel or saveBilevel):
-    im_px = im.load()                      
+    im_px = im.load()
     data = []
     for i in range(0,120):                # iterate over the columns
-      for j in range(0,320):              # and convert 255 vals to 1
-         data.append(1 if im_px[j,i] == 255 else 0)
+      for j in range(0,320):              # and convert 255 vals to 0 to match logic in Joystick.c and invertColormap option
+         data.append(0 if im_px[j,i] == 255 else 1)
 
     str_out = "#include <stdint.h>\n#include <avr/pgmspace.h>\n\nconst uint8_t image_data[0x12c1] PROGMEM = {"
     for i in range(0, (320*120) / 8):
        val = 0;
-       
+
        for j in range(0, 8):
           val |= data[(i * 8) + j] << j
-       
-       val = ~val & 0xFF;
+
+       if (invertColormap):
+          val = ~val & 0xFF;
+       else:
+          val = val & 0xFF;
+
        str_out += hex(val) + ", "         # append hexidecimal bytes
-                                          # to the output .c array 
+                                          # to the output .c array
     str_out += "0x0};"                    # of bytes
 
     with open('image.c', 'w') as f:       # save output into image.c
       f.write(str_out)
 
-    print(args[0] + " converted and saved to image.c")
+    if (invertColormap):
+       print("{} converted with inverted colormap and saved to image.c".format(args[0]))
+    else:
+       print("{} converted with original colormap and saved to image.c".format(args[0]))
 
 def usage():
   print("To convert to image.c: png2c.py <yourImage.png>")
+  print("To convert to an inverted image.c: png2c.py -i <yourImage.png>")
   print("To preview bilevel image: png2c.py -p <yourImage.png>")
   print("To save bilevel image: png2c.py -s <yourImage.png>")
 


### PR DESCRIPTION
Adding an -i option to bin2c.py and png2c.py to allow the user to specify an inverted colormap or the original image's colormap.